### PR TITLE
alias set-transient-map to set-temporary-overlay-map when not bound (fix...

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -350,6 +350,8 @@ KEYS is a list of character codes or strings."
               (scope-end (cdr scope))
               (evil-snipe--this-func (or evil-snipe--this-func 'evil-snipe-s))
               (charstr (concat keys)))
+	 (when (not (fboundp 'set-transient-map))
+	     (defalias 'set-transient-map 'set-temporary-overlay-map))
          (setq evil-snipe--transient-common-map-func
                (set-transient-map evil-snipe-mode-common-map))
          (setq evil-snipe--transient-map-func


### PR DESCRIPTION
...es mode on Emacs <24.4)
The mode was stil broken on 24.3 due to use of `set-transient-map`, which is also new in 24.4. Using **s** would highlight the matches, but failed to jump to them. This patch just aliases the function to it's previous name `set-temporary-overlay-map` if it's not bound. Basic functionality seems to work now (I haven't checked extensively).