### PR TITLE
Use correct key order during multi-character snipe

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -237,13 +237,13 @@ yourself too."
                          (nbutlast keys)))
                       (t ;; Otherwise add it
                        (when (eq key 'tab) (setq key ?\t)) ; literal tabs
-                       (setq keys (push key keys))
+                       (setq keys (append keys (list key)))
                        (cl-decf i)))
                 (when evil-snipe-enable-incremental-highlight
                   (evil-snipe--cleanup)
                   (evil-snipe--highlight-all count keys)
                   (add-hook 'pre-command-hook 'evil-snipe--cleanup))))))
-          (reverse keys)))))
+          keys))))
 
 (defun evil-snipe--bounds (&optional forward-p count)
   "Returns a cons cell containing (beg . end), which represents the search scope


### PR DESCRIPTION
Handle the typed characters in the correct order during a
multi-character snipe. For example,

```
  f TAB TAB TAB abc
```

should show "abc" in the prompt and highlight "abc" incrementally,
instead of "cba".