### PR TITLE
Allow to selectively turn off in certain modes

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -132,6 +132,12 @@ mode use:
                        (regexp :tag "Pattern"))))
 (define-obsolete-variable-alias 'evil-snipe-symbol-groups 'evil-snipe-aliases "v2.0.0")
 
+(defcustom evil-snipe-disabled-modes '()
+  "A list of modes in which the global evil-snipe minor modes
+will not be turned on."
+  :group 'evil-snipe
+  :type  '(list symbol))
+
 (defvar evil-snipe-auto-disable-substitute t
   "Disables evil's native s/S functionality (substitute) if non-nil. By default
 this is t, since they are mostly redundant with other motions. s can be done
@@ -597,12 +603,14 @@ interactive codes. KEYMAP is the transient map to activate afterwards."
 ;;;###autoload
 (defun turn-on-evil-snipe-mode ()
   "Enable evil-snipe-mode in the current buffer."
-  (evil-snipe-local-mode 1))
+  (unless (apply 'derived-mode-p evil-snipe-disabled-modes)
+    (evil-snipe-local-mode 1)))
 
 ;;;###autoload
 (defun turn-on-evil-snipe-override-mode ()
   "Enable evil-snipe-mode in the current buffer."
-  (evil-snipe-override-local-mode 1))
+  (unless (apply 'derived-mode-p evil-snipe-disabled-modes)
+    (evil-snipe-override-local-mode 1)))
 
 ;;;###autoload
 (defun turn-off-evil-snipe-mode ()


### PR DESCRIPTION
In Spacemacs we would like to leave the globalized mode on, but turn it off in certain other modes in which the `f` key has other more useful meanings. We can usually achieve this by leaving the `turn-off-...` function in that mode's hook, but in some rare cases `post-command-hook` runs after that, turning it on anyway.

This sort of option would make our lives a lot easier if it's agreeable with you.