### PR TITLE
Fixed the reversed prompt and incrementally highlighting

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -229,7 +229,7 @@ COUNT's directionality."
         (reverse
          (catch 'abort
            (while (> i 0)
-             (let* ((prompt (format "%d>%s" i (mapconcat #'char-to-string keys "")))
+             (let* ((prompt (format "%d>%s" i (mapconcat #'char-to-string (reverse keys) "")))
                     (key (evil-read-key (if evil-snipe-show-prompt prompt))))
                (cond
                 ;; TAB adds more characters if `evil-snipe-tab-increment'
@@ -254,7 +254,7 @@ COUNT's directionality."
                         (cl-decf i)))
                  (when evil-snipe-enable-incremental-highlight
                    (evil-snipe--cleanup)
-                   (evil-snipe--highlight-all count forward-p (mapcar #'evil-snipe--process-key keys))
+                   (evil-snipe--highlight-all count forward-p (mapcar #'evil-snipe--process-key (reverse keys)))
                    (add-hook 'pre-command-hook #'evil-snipe--cleanup))))))
            keys)))))
 


### PR DESCRIPTION
evil-snipes' prompt and incremental highlighting appears backwards when the search term's length has been extended with `<tab>`. They appear backwards because elisp's `push` adds to the front of the list. This PR puts the prompt and highlighting in the correct order.

An example of searching for `abcd` with `sa<tab><tab>bcd`.
[![asciicast](https://asciinema.org/a/xxwZlIFPNipLA6Uv2hbREFBIo.png)](https://asciinema.org/a/xxwZlIFPNipLA6Uv2hbREFBIo)

