### PR TITLE
added undo tree visualizer to disabled modes

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -135,7 +135,8 @@ mode use:
 (defcustom evil-snipe-disabled-modes
   '(org-agenda-mode magit-mode git-rebase-mode elfeed-show-mode
     elfeed-search-mode ranger-mode magit-repolist-mode mu4e-main-mode
-    mu4e-view-mode mu4e-headers-mode mu4e~update-mail-mode)
+    mu4e-view-mode mu4e-headers-mode mu4e~update-mail-mode 
+    undo-tree-visualizer-mode)
   "A list of modes in which the global evil-snipe minor modes
 will not be turned on."
   :group 'evil-snipe


### PR DESCRIPTION
undo tree is part of evil, but evil-snipe overrides some of the keybindings used for navigation. There is no need to evil-snipe in the undo tree visualizer. 