### PR TITLE
Wrap forward/backward-key within evil-snipe--transient-map

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -527,7 +527,7 @@ choose the function names."
             count keys (evil-snipe--transient-map ,forward-key ,backward-key))))
 
        (evil-define-motion ,backward-fn (count keys)
-         ,(concat "Performs an backwards `" (symbol-name forward-fn) "'.")
+         ,(concat "Performs a backwards `" (symbol-name forward-fn) "'.")
          :jump t
          (interactive
           (let ((count (when current-prefix-arg (prefix-numeric-value current-prefix-arg))))

--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -357,8 +357,8 @@ or behind it if COUNT is negative."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map evil-snipe-parent-transient-map)
     (when evil-snipe-repeat-keys
-      (define-key map forward-key  #'evil-snipe-repeat)
-      (define-key map backward-key #'evil-snipe-repeat-reverse))
+      (define-key map (kbd forward-key)  #'evil-snipe-repeat)
+      (define-key map (kbd backward-key) #'evil-snipe-repeat-reverse))
     map))
 
 


### PR DESCRIPTION
This allows `(evil-snipe-def 1 'exclusive "<down>" "<up>")`.