### PR TITLE
Correct default for `evil-snipe-smart-case` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ It seems `evil-snipe-override-mode` causes problems in Magit buffers, to fix thi
   after a search will repeat it. If `evil-snipe-override-evil` is non-nil, this applies
   to f/F/t/T as well.
 * `evil-snipe-show-prompt` (default `t`) Whether or not to show the "N>" prompt.
-* `evil-snipe-smart-case` (default `t`) If non-nil, searches will be case-insenstive
+* `evil-snipe-smart-case` (default `nil`) If non-nil, searches will be case-insenstive
   unless your search contains a capital letter.
 * `evil-snipe-auto-scroll` (default `nil`) If non-nil, the window will scroll to follow
   the cursor.


### PR DESCRIPTION
Just changed to show the actual default