### PR TITLE
fix invisible txt bug

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -395,7 +395,7 @@ interactive codes. KEYMAP is the transient map to activate afterwards."
       (setq regex (concat regex "[^ \t]")))
     (when (setq result (re-search-forward regex scope t count))
       (if (or (invisible-p (match-beginning 0))
-              (invisible-p (match-end 0)))
+              (invisible-p (1- (match-end 0))))
           (evil-snipe--seek-re data scope count)
         result))))
 


### PR DESCRIPTION
Fix issue #69.
The function "evil-snipe--seek-re" skips a string if the first or last char is invisible (e.g. happens with org links, org headers, etc.). However in the original code when checking the last char it checks the char after it instead (so snipes for strings right before the invisible text would fail). This pull request fixes that.