### PR TITLE
Fix evil-snipe-scope type

### DIFF
--- a/evil-snipe.el
+++ b/evil-snipe.el
@@ -92,12 +92,12 @@ See `evil-snipe-spillover-scope' to fall back to another scope if the first
 snipe yields no matches."
   :group 'evil-snipe
   :type '(choice
-          (const :tag "Forward line" 'line)
-          (const :tag "Forward buffer" 'buffer)
-          (const :tag "Forward visible buffer" 'visible)
-          (const :tag "Whole line" 'whole-line)
-          (const :tag "Whole buffer" 'whole-buffer)
-          (const :tag "Whole visible buffer" 'whole-visible)))
+          (const :tag "Forward line" line)
+          (const :tag "Forward buffer" buffer)
+          (const :tag "Forward visible buffer" visible)
+          (const :tag "Whole line" whole-line)
+          (const :tag "Whole buffer" whole-buffer)
+          (const :tag "Whole visible buffer" whole-visible)))
 
 (defcustom evil-snipe-repeat-scope nil
   "Dictates the scope of repeat searches.


### PR DESCRIPTION
The `(const ...)` type in choice clause should be written without the quote mark. See tab-first-completion for example. This makes Emacs 29's new `setopt` happy.